### PR TITLE
파트너 요청 수락 시 채팅방 생성 메세지 전송

### DIFF
--- a/src/main/java/com/mfc/coordinating/common/client/AuthClient.java
+++ b/src/main/java/com/mfc/coordinating/common/client/AuthClient.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // 추후 로드밸런싱 활용해서 직접 서비스에 접속 가능하도록 변경 (유레카 서버로 가능 포트 안거쳐도 됨)
-@FeignClient(name = "auth-service", url = "https://myfaco.shop/auth-service")
+@FeignClient(name = "auth-service")
 public interface AuthClient {
 	@GetMapping("/members/birth-gender/{uuid}")
 	AuthInfoResponse getAuthInfo(@PathVariable String uuid);

--- a/src/main/java/com/mfc/coordinating/common/client/MemberClient.java
+++ b/src/main/java/com/mfc/coordinating/common/client/MemberClient.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 // 추후 로드밸런싱 활용해서 직접 서비스에 접속 가능하도록 변경 (유레카 서버로 가능 포트 안거쳐도 됨)
-@FeignClient(name = "member-service", url = "https://myfaco.shop/member-service")
+@FeignClient(name = "member-service")
 public interface MemberClient {
 	@GetMapping("/users/nickname-image/{userId}")
 	MemberInfoResponse getMemberInfo(@PathVariable String userId);

--- a/src/main/java/com/mfc/coordinating/requests/application/RequestsEventProducer.java
+++ b/src/main/java/com/mfc/coordinating/requests/application/RequestsEventProducer.java
@@ -4,6 +4,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 import com.mfc.coordinating.requests.dto.kafka.CashDeductionRequestDto;
+import com.mfc.coordinating.requests.dto.kafka.CreateChatRoomDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,5 +26,9 @@ public class RequestsEventProducer {
 		} catch (Exception e) {
 			log.error("Failed to publish cash deduction event", e);
 		}
+	}
+
+	public void createChatRoom(CreateChatRoomDto dto) {
+		kafkaTemplate.send("create-chatroom", dto);
 	}
 }

--- a/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
@@ -1,7 +1,10 @@
 package com.mfc.coordinating.requests.application;
 
+import static com.mfc.coordinating.requests.enums.RequestsStates.*;
+
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,6 +23,7 @@ import com.mfc.coordinating.common.client.MemberInfoResponse;
 import com.mfc.coordinating.common.exception.BaseException;
 import com.mfc.coordinating.common.response.BaseResponseStatus;
 import com.mfc.coordinating.requests.domain.Requests;
+import com.mfc.coordinating.requests.dto.kafka.CreateChatRoomDto;
 import com.mfc.coordinating.requests.dto.req.AuthInfoRequestDto;
 import com.mfc.coordinating.requests.dto.req.RequestsCreateReqDto;
 import com.mfc.coordinating.requests.dto.req.RequestsUpdateReqDto;
@@ -180,6 +184,18 @@ public class RequestsServiceImpl implements RequestsService {
 
 		requests.updatePartnerStatus(partnerId, status);
 		requestsRepository.save(requests);
+
+		if(status == RESPONSEACCEPT) {
+			List<String> members = new ArrayList<>();
+			members.add(partnerId);
+			members.add(uuid);
+
+			requestsEventProducer.createChatRoom(
+					CreateChatRoomDto.builder()
+							.requestId(requestId)
+							.members(members)
+							.build());
+		}
 	}
 
 	private Pageable getPageable(int page, int pageSize, RequestsListSortType sortType) {

--- a/src/main/java/com/mfc/coordinating/requests/dto/kafka/CreateChatRoomDto.java
+++ b/src/main/java/com/mfc/coordinating/requests/dto/kafka/CreateChatRoomDto.java
@@ -1,0 +1,13 @@
+package com.mfc.coordinating.requests.dto.kafka;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateChatRoomDto {
+	private String requestId;
+	private List<String> members;
+}


### PR DESCRIPTION
## 📣 파트너 요청 수락 시 채팅방 생성 메세지 전송
### 📅 2024-06-18

### 🌵Branch
`feature/cathroom`  → `develop`

### 📢 Description
- 파트너 응답 상태 변경 로직 수정 : 요청 수락 시 채팅 서비스로 채팅방 생성 메세지 전송
- `AuthClient`, `MemberClient` url 제거 및 관련 설정 추가

### 💬Issue Number
close #35

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note