### PR TITLE
fix: 값 받을 때 기본검증 및 카프카 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	// feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+	// validator
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/mfc/coordinating/config/KafkaConfig.java
+++ b/src/main/java/com/mfc/coordinating/config/KafkaConfig.java
@@ -20,6 +20,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import com.mfc.coordinating.requests.dto.kafka.PaymentCompletedEvent;
 
 @EnableKafka
 @Configuration
@@ -46,7 +47,7 @@ public class KafkaConfig {
 	}
 
 	@Bean
-	public ConsumerFactory<String, Object> consumerFactory() {
+	public ConsumerFactory<String, PaymentCompletedEvent> consumerFactory() {
 		Map<String, Object> configProps = new HashMap<>();
 		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
@@ -54,13 +55,18 @@ public class KafkaConfig {
 		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-		return new DefaultKafkaConsumerFactory<>(configProps);
+		return new DefaultKafkaConsumerFactory<>(
+			configProps,
+			new StringDeserializer(),
+			new JsonDeserializer<>(PaymentCompletedEvent.class, false)
+		);
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
-		ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+	public ConcurrentKafkaListenerContainerFactory<String, PaymentCompletedEvent> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, PaymentCompletedEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory());
+		factory.setConcurrency(2);
 		return factory;
 	}
 }

--- a/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
@@ -41,8 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class RequestsServiceImpl implements RequestsService {
 	private final RequestsRepository requestsRepository;
-	private final RequestsEventProducer requestsEventProducer;
-	private final ObjectMapper objectMapper;
 	private final RequestMapper requestMapper;
     private final AuthClient authClient;
 	private final MemberClient memberClient;
@@ -57,23 +55,18 @@ public class RequestsServiceImpl implements RequestsService {
 		UserInfoRequestDto userInfoResponse = member_response.getResult();
 
 		String userImageUrl = userInfoResponse.getUserImageUrl();
-		if (userImageUrl == null) {
-			userImageUrl = "";
-		}
+
 		String userNickName = userInfoResponse.getUserNickName();
-		if (userNickName == null) {
-			userNickName = "user";
-		}
+
 		Short userGender = authInfoResponse.getUserGender();
-		if (userGender == null) {
-			userGender = 0;
-		}
+
 		LocalDate userBirth = authInfoResponse.getUserBirth();
 
 		int userAge = LocalDate.now().getYear() - userBirth.getYear();
 
 		// Requests 엔티티 생성 및 저장
-		Requests requests = getRequests(requestsCreateReqDto, uuid, userImageUrl,
+		Requests requests = getRequests(requestsCreateReqDto, uuid,
+			userImageUrl != null ? userImageUrl : "",
 			userNickName, userGender, userAge);
 
 		requestsRepository.save(requests);

--- a/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/requests/application/RequestsServiceImpl.java
@@ -134,6 +134,8 @@ public class RequestsServiceImpl implements RequestsService {
 			dto.getReferenceImageUrls(),
 			dto.getMyImageUrls()
 		);
+
+		requestsRepository.save(requests);
 	}
 
 	@Transactional

--- a/src/main/java/com/mfc/coordinating/requests/dto/req/ConfirmProposalRequest.java
+++ b/src/main/java/com/mfc/coordinating/requests/dto/req/ConfirmProposalRequest.java
@@ -2,6 +2,8 @@ package com.mfc.coordinating.requests.dto.req;
 
 import java.time.Instant;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,5 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ConfirmProposalRequest {
 	private Double price;
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	private Instant confirmDate;
 }

--- a/src/main/java/com/mfc/coordinating/requests/dto/req/RequestsCreateReqDto.java
+++ b/src/main/java/com/mfc/coordinating/requests/dto/req/RequestsCreateReqDto.java
@@ -2,6 +2,7 @@ package com.mfc.coordinating.requests.dto.req;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RequestsCreateReqDto {
+	@NotNull
 	private String title;
+	@NotNull
 	private String description;
 	private String situation;
 	private String budget;

--- a/src/main/java/com/mfc/coordinating/requests/dto/req/RequestsUpdateReqDto.java
+++ b/src/main/java/com/mfc/coordinating/requests/dto/req/RequestsUpdateReqDto.java
@@ -2,6 +2,7 @@ package com.mfc.coordinating.requests.dto.req;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RequestsUpdateReqDto {
+	@NotNull
 	private String title;
+	@NotNull
 	private String description;
 	private String situation;
 	private String budget;

--- a/src/main/java/com/mfc/coordinating/requests/presentation/RequestsController.java
+++ b/src/main/java/com/mfc/coordinating/requests/presentation/RequestsController.java
@@ -166,6 +166,8 @@
 package com.mfc.coordinating.requests.presentation;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.modelmapper.ModelMapper;
@@ -182,7 +184,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.coordinating.common.response.BaseResponse;
 import com.mfc.coordinating.requests.application.RequestsService;
-import com.mfc.coordinating.requests.dto.req.ConfirmProposalRequest;
 import com.mfc.coordinating.requests.dto.req.RequestsCreateReqDto;
 import com.mfc.coordinating.requests.dto.req.RequestsUpdateReqDto;
 import com.mfc.coordinating.requests.dto.res.MyRequestListResponse;
@@ -193,6 +194,7 @@ import com.mfc.coordinating.requests.enums.RequestsStates;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -209,7 +211,7 @@ public class RequestsController {
 	@Operation(summary = "코디 요청서 생성", description = "유저가 작성한 코디 요청서를 저장합니다.")
 	public BaseResponse<Void> createRequests(
 		@RequestHeader String uuid,
-		@RequestBody RequestsCreateReqDto requestsCreateReqDto
+		@Valid @RequestBody RequestsCreateReqDto requestsCreateReqDto
 	) {
 		requestsService.createRequests(requestsCreateReqDto, uuid);
 		return new BaseResponse<>();
@@ -264,7 +266,7 @@ public class RequestsController {
 	public BaseResponse<Void> updateRequests(
 		@RequestHeader String uuid,
 		@PathVariable String requestId,
-		@RequestBody RequestsUpdateReqDto requestsUpdateReqDto
+		@Valid @RequestBody RequestsUpdateReqDto requestsUpdateReqDto
 	) {
 		requestsService.updateRequests(requestsUpdateReqDto, requestId, uuid);
 		return new BaseResponse<>();
@@ -286,9 +288,10 @@ public class RequestsController {
 		@RequestHeader String uuid,
 		@PathVariable String requestId,
 		@PathVariable String partnerId,
-		@RequestParam Instant deadline
+		@RequestParam LocalDate deadline
 	) {
-		requestsService.updateProposal(requestId, partnerId, uuid, deadline);
+		Instant date = deadline.atStartOfDay(ZoneOffset.UTC).toInstant();
+		requestsService.updateProposal(requestId, partnerId, uuid, date);
 		return new BaseResponse<>();
 	}
 
@@ -304,15 +307,15 @@ public class RequestsController {
 		return new BaseResponse<>();
 	}
 
-	@PutMapping("/confirm/{requestId}/{partnerId}")
-	@Operation(summary = "파트너 확정 제안", description = "파트너가 코디 요청서에 대한 확정 제안을 합니다.")
-	public BaseResponse<Void> confirmProposal(
-		@PathVariable String requestId,
-		@PathVariable String partnerId,
-		@RequestBody ConfirmProposalRequest request
-	) {
-		requestsService.confirmProposal(requestId, partnerId, request.getPrice(), request.getConfirmDate());
-		return new BaseResponse<>();
-	}
+	// @PutMapping("/confirm/{requestId}/{partnerId}")
+	// @Operation(summary = "파트너 확정 제안", description = "파트너가 코디 요청서에 대한 확정 제안을 합니다.")
+	// public BaseResponse<Void> confirmProposal(
+	// 	@PathVariable String requestId,
+	// 	@PathVariable String partnerId,
+	// 	@RequestBody ConfirmProposalRequest request
+	// ) {
+	// 	requestsService.confirmProposal(requestId, partnerId, request.getPrice(), request.getConfirmDate());
+	// 	return new BaseResponse<>();
+	// }
 
 }

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
@@ -11,11 +11,6 @@ public class TradeEventProducer {
 
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 
-	public void sendTradeCreatedEvent(String userUuid, String partnerUuid, Double amount, Long tradeId) {
-		String message = String.format("UserUuid: %s, PartnerUuid: %s, Amount: %.2f, TradeId: %d", userUuid, partnerUuid, amount, tradeId);
-		kafkaTemplate.send("user-settlement", message);
-	}
-
 	public void sendTradeSettledEvent(String userUuid, String partnerUuid, Double amount, Long tradeId) {
 		String message = String.format("UserUuid: %s, PartnerUuid: %s, Amount: %.2f, TradeId: %d", userUuid, partnerUuid, amount, tradeId);
 		kafkaTemplate.send("partner-completion", message);

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
@@ -3,6 +3,8 @@ package com.mfc.coordinating.trade.application;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
+import com.mfc.coordinating.trade.dto.kafka.TradeSettledEventDto;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -12,7 +14,7 @@ public class TradeEventProducer {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 
 	public void sendTradeSettledEvent(String userUuid, String partnerUuid, Double amount, Long tradeId) {
-		String message = String.format("UserUuid: %s, PartnerUuid: %s, Amount: %.2f, TradeId: %d", userUuid, partnerUuid, amount, tradeId);
-		kafkaTemplate.send("partner-completion", message);
+		TradeSettledEventDto eventDto = new TradeSettledEventDto(userUuid, partnerUuid, amount, tradeId);
+		kafkaTemplate.send("partner-completion", eventDto);
 	}
 }

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeExpiredEventConsumer.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeExpiredEventConsumer.java
@@ -3,6 +3,10 @@ package com.mfc.coordinating.trade.application;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
+import com.mfc.coordinating.requests.dto.kafka.PaymentCompletedEvent;
+import com.mfc.coordinating.trade.domain.Trade;
+import com.mfc.coordinating.trade.infrastructure.TradeRepository;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -10,9 +14,21 @@ import lombok.RequiredArgsConstructor;
 public class TradeExpiredEventConsumer {
 
 	private final TradeService tradeService;
+	private final TradeRepository tradeRepository;
 
 	@KafkaListener(topics = "expired-requests", groupId = "trade-expired-group")
 	public void consumeTradeExpiredEvent(Long tradeId) {
 		tradeService.handleTradeExpired(tradeId);
+	}
+
+	@KafkaListener(topics = "payment-completed", containerFactory = "kafkaListenerContainerFactory")
+	public void consumePaymentCompletedEvent(PaymentCompletedEvent event) {
+		String requestId = event.getRequestId();
+		String partnerId = event.getPartnerId();
+
+		Trade trade = tradeRepository.findByRequestIdAndPartnerId(requestId, partnerId)
+			.orElseThrow(() -> new IllegalStateException("Trade not found"));
+		trade.tradeSettled();
+		tradeRepository.save(trade);
 	}
 }

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
@@ -86,7 +86,7 @@ public class TradeServiceImpl implements TradeService {
 		}
 		// dirty checking
 		trade.tradeSettled();
-		tradeEventProducer.sendTradeSettledEvent(trade.getPartnerId(), trade.getUserId(),
+		tradeEventProducer.sendTradeSettledEvent(trade.getUserId(), trade.getPartnerId(),
 			trade.getTotalPrice(), trade.getTradeId());
 
 	}

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
@@ -30,8 +30,8 @@ public class TradeServiceImpl implements TradeService {
 		}
 		Trade trade = mapToEntity(tradeRequest);
 		Trade createdTrade = tradeRepository.save(trade);
-		tradeEventProducer.sendTradeCreatedEvent(tradeRequest.getUserId(), tradeRequest.getPartnerId(),
-			tradeRequest.getTotalPrice(), createdTrade.getTradeId());
+		// tradeEventProducer.sendTradeCreatedEvent(tradeRequest.getUserId(), tradeRequest.getPartnerId(),
+		// 	tradeRequest.getTotalPrice(), createdTrade.getTradeId(), trade);
 		return mapToResponse(createdTrade);
 	}
 
@@ -92,8 +92,8 @@ public class TradeServiceImpl implements TradeService {
 	}
 
 	@KafkaListener(topics = "coordinates-submitted-topic", groupId = "trade-coordinates-submitted-group")
-	public void handleCoordinatesSubmitted(Long requestHistoryId) {
-		Trade trade = tradeRepository.findByRequestHistoryId(requestHistoryId)
+	public void handleCoordinatesSubmitted(String requestId) {
+		Trade trade = tradeRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new BaseException(BaseResponseStatus.CONFIRMS_NOT_FOUND));
 
 		trade.setCoordinatesSubmitted();
@@ -116,7 +116,7 @@ public class TradeServiceImpl implements TradeService {
 			.options(tradeRequest.getOptions())
 			.totalPrice(tradeRequest.getTotalPrice())
 			.dueDate(tradeRequest.getDueDate())
-			.requestHistoryId(tradeRequest.getRequestHistoryId())
+			.requestId(tradeRequest.getRequestId())
 			.build();
 	}
 
@@ -128,7 +128,7 @@ public class TradeServiceImpl implements TradeService {
 			.options(trade.getOptions())
 			.totalPrice(trade.getTotalPrice())
 			.dueDate(trade.getDueDate())
-			.requestHistoryId(trade.getRequestHistoryId())
+			.requestId(trade.getRequestId())
 			.status(trade.getStatus())
 			.isCoordinatesSubmitted(trade.getIsCoordinatesSubmitted())
 			.build();

--- a/src/main/java/com/mfc/coordinating/trade/domain/Trade.java
+++ b/src/main/java/com/mfc/coordinating/trade/domain/Trade.java
@@ -44,8 +44,8 @@ public class Trade extends BaseEntity {
 	@Column(name = "due_date", nullable = false)
 	private LocalDate dueDate;
 	
-	@Column(name = "request_history_id", nullable = false)
-	private Long requestHistoryId;
+	@Column(name = "request_id", nullable = false)
+	private String requestId;
 
 	@Column(name = "status", nullable = false)
 	private TradeStatus status;
@@ -54,14 +54,14 @@ public class Trade extends BaseEntity {
 	private Boolean isCoordinatesSubmitted;
 
 	@Builder
-	public Trade(String partnerId, String userId, Long options, Double totalPrice, LocalDate dueDate, Long requestHistoryId,
+	public Trade(String partnerId, String userId, Long options, Double totalPrice, LocalDate dueDate, String requestId,
 		TradeStatus status, boolean isCoordinatesSubmitted) {
 		this.partnerId = partnerId;
 		this.userId = userId;
 		this.options = options;
 		this.totalPrice = totalPrice;
 		this.dueDate = dueDate;
-		this.requestHistoryId = requestHistoryId;
+		this.requestId = requestId;
 		this.status = TradeStatus.TRADE_PAID;
 		this.isCoordinatesSubmitted = false;
 	}

--- a/src/main/java/com/mfc/coordinating/trade/dto/kafka/TradeSettledEventDto.java
+++ b/src/main/java/com/mfc/coordinating/trade/dto/kafka/TradeSettledEventDto.java
@@ -1,0 +1,17 @@
+package com.mfc.coordinating.trade.dto.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TradeSettledEventDto {
+	private String userUuid;
+	private String partnerUuid;
+	private Double amount;
+	private Long tradeId;
+}

--- a/src/main/java/com/mfc/coordinating/trade/dto/request/TradeRequest.java
+++ b/src/main/java/com/mfc/coordinating/trade/dto/request/TradeRequest.java
@@ -11,5 +11,5 @@ public class TradeRequest {
 	private Long options;
 	private Double totalPrice;
 	private LocalDate dueDate;
-	private Long requestHistoryId;
+	private String requestId;
 }

--- a/src/main/java/com/mfc/coordinating/trade/dto/response/TradeResponse.java
+++ b/src/main/java/com/mfc/coordinating/trade/dto/response/TradeResponse.java
@@ -16,7 +16,7 @@ public class TradeResponse {
 	private Long options;
 	private Double totalPrice;
 	private LocalDate dueDate;
-	private Long requestHistoryId;
+	private String requestId;
 	private TradeStatus status;
 	private Boolean isCoordinatesSubmitted;
 }

--- a/src/main/java/com/mfc/coordinating/trade/infrastructure/TradeRepository.java
+++ b/src/main/java/com/mfc/coordinating/trade/infrastructure/TradeRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.mfc.coordinating.trade.domain.Trade;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
-	Optional<Trade> findByRequestHistoryId(Long requestHistoryId);
+	Optional<Trade> findByRequestIdAndPartnerId(String requestId, String partnerId);
+	Optional<Trade> findByRequestId(String requestId);
 }

--- a/src/main/java/com/mfc/coordinating/trade/presentation/TradeController.java
+++ b/src/main/java/com/mfc/coordinating/trade/presentation/TradeController.java
@@ -17,11 +17,14 @@ import com.mfc.coordinating.trade.dto.request.TradeUpdateRequest;
 import com.mfc.coordinating.trade.dto.response.TradeResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/trade")
+@Tag(name = "Trade", description = "코디와 유저 매칭 후 최종 내역(채팅방 확정서)")
+
 public class TradeController {
 	private final TradeService tradeService;
 
@@ -68,7 +71,7 @@ public class TradeController {
 	}
 
 	@PutMapping("/user/{id}")
-	@Operation(summary = "제안 수락", description = "제안을 수락합니다.")
+	@Operation(summary = "제안 수락", description = "코디네이터가 제출한 코디를 보고 최종 확정 여부 결정(파트너에게 캐시 최종 전달)")
 	public BaseResponse<Void> updateTradeStatus(@PathVariable Long id,
 		@RequestHeader("User-UUID") String userUuid) {
 		tradeService.updateTradeStatus(id, userUuid);


### PR DESCRIPTION
## 📣값 받을 때 기본검증 및 카프카 설정 변경
### 📅 2024.06.19

### 🌵Branch
feature/confirm-pay-api -> develop

### 📢 Description

- valid 어노테이션 추가로 받기 전 검증 추가 및 localdatetime으로 받아서 instant로 변경하는 ㅀ직 추가 트레이드 결제시 상태 변경 하도록 수정
-  이미지 없을 떄 기본으로 공백 들어가게 설정
- [최종 코디 제출후 유저가 확정 시 카프카 토픽 발행 string에서 TradeSettledEventDto로 변경](https://github.com/personull-mfc/mfc-coordinating/commit/db60e72d7cd8e377b8e6037e816e412a3f4e4e89)

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)