### PR TITLE
fix: 거래 최종 완료시 request에서 trade 토픽 구독하여 상태 변경

### DIFF
--- a/src/main/java/com/mfc/coordinating/config/KafkaConfig.java
+++ b/src/main/java/com/mfc/coordinating/config/KafkaConfig.java
@@ -138,6 +138,20 @@ public class KafkaConfig {
 		return createListenerContainerFactory(coordinatesSubmittedConsumerFactory());
 	}
 
+	@Bean
+	public ConsumerFactory<String, TradeSettledEventDto> TradeSettledConsumerFactory() {
+		return new DefaultKafkaConsumerFactory<>(
+			getCommonConsumerConfig(),
+			new StringDeserializer(),
+			new JsonDeserializer<>(TradeSettledEventDto.class, false)
+		);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, TradeSettledEventDto> tradeSettledKafkaListenerContainerFactory() {
+		return createListenerContainerFactory(TradeSettledConsumerFactory());
+	}
+
 	private <T> ConcurrentKafkaListenerContainerFactory<String, T> createListenerContainerFactory(ConsumerFactory<String, T> consumerFactory) {
 		ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory);

--- a/src/main/java/com/mfc/coordinating/requests/enums/RequestsStates.java
+++ b/src/main/java/com/mfc/coordinating/requests/enums/RequestsStates.java
@@ -9,5 +9,5 @@ public enum RequestsStates {
 	PROPOSALREJECT,		// 거래 거절
 	CONFIRMED,			// 거래 확정
 	COORDINATE_RECEIVED, // 코디 받은 상태
-	CLOSING				// 마감(코디완료)
+	CLOSED				// 마감(코디완료)
 }

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeEventProducer.java
@@ -15,8 +15,9 @@ public class TradeEventProducer {
 
 	private final KafkaTemplate<String, TradeSettledEventDto> tradeSettledKafkaTemplate;
 
-	public void sendTradeSettledEvent(String userUuid, String partnerUuid, Double amount, Long tradeId, LocalDate dueDate) {
-		TradeSettledEventDto eventDto = new TradeSettledEventDto(userUuid, partnerUuid, dueDate, amount, tradeId);
+	public void sendTradeSettledEvent(String userUuid, String partnerUuid, Double amount,
+		Long tradeId, LocalDate dueDate, String requestId) {
+		TradeSettledEventDto eventDto = new TradeSettledEventDto(userUuid, partnerUuid, dueDate, amount, tradeId, requestId);
 		tradeSettledKafkaTemplate.send("partner-completion", eventDto);
 	}
 }

--- a/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
+++ b/src/main/java/com/mfc/coordinating/trade/application/TradeServiceImpl.java
@@ -31,7 +31,7 @@ public class TradeServiceImpl implements TradeService {
 		Trade trade = mapToEntity(tradeRequest);
 		Trade createdTrade = tradeRepository.save(trade);
 		tradeEventProducer.sendTradeSettledEvent(tradeRequest.getUserId(), tradeRequest.getPartnerId(),
-			tradeRequest.getTotalPrice(), createdTrade.getTradeId(), tradeRequest.getDueDate());
+			tradeRequest.getTotalPrice(), createdTrade.getTradeId(), tradeRequest.getDueDate(), tradeRequest.getRequestId());
 		return mapToResponse(createdTrade);
 	}
 
@@ -87,7 +87,7 @@ public class TradeServiceImpl implements TradeService {
 		// dirty checking
 		trade.tradeSettled();
 		tradeEventProducer.sendTradeSettledEvent(trade.getUserId(), trade.getPartnerId(),
-			trade.getTotalPrice(), trade.getTradeId(), trade.getDueDate());
+			trade.getTotalPrice(), trade.getTradeId(), trade.getDueDate(), trade.getRequestId());
 
 	}
 

--- a/src/main/java/com/mfc/coordinating/trade/dto/kafka/TradeSettledEventDto.java
+++ b/src/main/java/com/mfc/coordinating/trade/dto/kafka/TradeSettledEventDto.java
@@ -17,4 +17,5 @@ public class TradeSettledEventDto {
 	private LocalDate dueDate;
 	private Double amount;
 	private Long tradeId;
+	private String requestId;
 }


### PR DESCRIPTION
## 📣거래 최종 완료시 request에서 trade 토픽 구독하여 상태 변경
### 📅날짜 -  2023.06.25
### 🌵Branch
feature/request-status-closed  → develop
### 📢 Description
- trade 토픽을 구독하여 거래 최종 완료 이벤트를 수신합니다.
- 수신한 이벤트를 기반으로 request의 상태를 'CLOSED'로 업데이트합니다.
### 💬Issue Number
close #47 
### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
### 🔖Note
- Kafka 컨슈머 설정을 추가했으니 리뷰 시 확인 부탁드립니다.
- 거래 완료 이벤트 수신 후 상태 변경 과정에서 발생할 수 있는 예외 상황에 대한 처리를 추가했습니다.